### PR TITLE
Slight Image bug if loaded without a loader

### DIFF
--- a/src/main/java/com/mrcrayfish/device/api/app/component/Image.java
+++ b/src/main/java/com/mrcrayfish/device/api/app/component/Image.java
@@ -155,7 +155,10 @@ public class Image extends Component
     @Override
     public void handleOnLoad()
     {
-        loader.setup(this);
+        if (loader != null)
+        {
+            loader.setup(this);
+        }
     }
 
     @Override


### PR DESCRIPTION
If the loader is null this throws `NullPointerException`. The main culprit is the when you specify no images for the slide show component. This can be caused by not specifying any screenshots in the application info and opening the app in the app store.