### PR TITLE
Created an Annotation for Registering Apps

### DIFF
--- a/src/main/java/com/mrcrayfish/device/MrCrayfishDeviceMod.java
+++ b/src/main/java/com/mrcrayfish/device/MrCrayfishDeviceMod.java
@@ -1,6 +1,7 @@
 package com.mrcrayfish.device;
 
 import com.mrcrayfish.device.api.ApplicationManager;
+import com.mrcrayfish.device.api.app.registry.ApplicationRegistry;
 import com.mrcrayfish.device.api.print.PrintingManager;
 import com.mrcrayfish.device.api.task.TaskManager;
 import com.mrcrayfish.device.core.io.task.*;
@@ -68,6 +69,8 @@ public class MrCrayfishDeviceMod
 		}
 		logger = event.getModLog();
 
+		ApplicationRegistry.populateApps(event.getAsmData());
+
 		DeviceConfig.load(event.getSuggestedConfigurationFile());
 		MinecraftForge.EVENT_BUS.register(new DeviceConfig());
 
@@ -92,6 +95,7 @@ public class MrCrayfishDeviceMod
 		MinecraftForge.EVENT_BUS.register(new EmailEvents());
 		MinecraftForge.EVENT_BUS.register(new BankEvents());
 
+		ApplicationRegistry.registerApps();
 		registerApplications();
 
 		proxy.init();
@@ -161,7 +165,6 @@ public class MrCrayfishDeviceMod
 		else
 		{
 			// Applications (Developers)
-			ApplicationManager.registerApplication(new ResourceLocation(Reference.MOD_ID, "example"), ApplicationExample.class);
 			ApplicationManager.registerApplication(new ResourceLocation(Reference.MOD_ID, "icons"), ApplicationIcons.class);
 			ApplicationManager.registerApplication(new ResourceLocation(Reference.MOD_ID, "text_area"), ApplicationTextArea.class);
 			ApplicationManager.registerApplication(new ResourceLocation(Reference.MOD_ID, "test"), ApplicationTest.class);

--- a/src/main/java/com/mrcrayfish/device/api/ApplicationManager.java
+++ b/src/main/java/com/mrcrayfish/device/api/ApplicationManager.java
@@ -2,6 +2,7 @@ package com.mrcrayfish.device.api;
 
 import com.mrcrayfish.device.MrCrayfishDeviceMod;
 import com.mrcrayfish.device.api.app.Application;
+import com.mrcrayfish.device.api.app.registry.IAppContainer;
 import com.mrcrayfish.device.object.AppInfo;
 import net.minecraft.util.ResourceLocation;
 
@@ -14,6 +15,10 @@ public final class ApplicationManager
 	private static final Map<ResourceLocation, AppInfo> APP_INFO = new HashMap<>();
 
 	private ApplicationManager() {}
+
+	public static Application registerApplication(IAppContainer app){
+		return registerApplication(app.getAppId(), app.getContainedAppClass());
+	}
 
 	/**
 	 * Registers an application into the application list

--- a/src/main/java/com/mrcrayfish/device/api/app/registry/App.java
+++ b/src/main/java/com/mrcrayfish/device/api/app/registry/App.java
@@ -1,0 +1,15 @@
+package com.mrcrayfish.device.api.app.registry;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface App {
+    String modId();
+    String appId();
+    boolean isDebug() default false;
+    boolean isSystemApp() default false;
+}

--- a/src/main/java/com/mrcrayfish/device/api/app/registry/ApplicationRegistry.java
+++ b/src/main/java/com/mrcrayfish/device/api/app/registry/ApplicationRegistry.java
@@ -1,0 +1,74 @@
+package com.mrcrayfish.device.api.app.registry;
+
+import com.mrcrayfish.device.MrCrayfishDeviceMod;
+import com.mrcrayfish.device.api.ApplicationManager;
+import com.mrcrayfish.device.api.app.Application;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.discovery.ASMDataTable;
+
+import java.lang.annotation.Annotation;
+import java.util.*;
+
+public class ApplicationRegistry {
+    private static final Set<IAppContainer> apps = new HashSet<>();
+
+    public static void populateApps(ASMDataTable asmDataTable){
+        MrCrayfishDeviceMod.getLogger().info("Populating annotated apps...");
+        final Set<ASMDataTable.ASMData> rawapps = asmDataTable.getAll(App.class.getName());
+        for(ASMDataTable.ASMData it : rawapps){
+            try {
+                final String name = it.getClassName();
+                final Class<?> clazz = Class.forName(name);
+                if(clazz.getSuperclass() == Application.class){
+                    final Class<? extends Application> claz = clazz.asSubclass(Application.class);
+                    final Annotation[] anns = claz.getAnnotations();
+                    for(Annotation a : anns){
+                        final String n = a.annotationType().getCanonicalName();
+                        if(n.equals(App.class.getCanonicalName())){
+                            final App app = (App)a;
+                            apps.add(newAppContainer(app, claz));
+                        }
+                    }
+                }
+            } catch (ClassNotFoundException e) {
+                e.printStackTrace();
+            }
+        }
+        MrCrayfishDeviceMod.getLogger().info("\tDone!");
+    }
+
+    private static IAppContainer newAppContainer(App app, Class<? extends Application> clazz){
+        MrCrayfishDeviceMod.getLogger().info("Constructing new app container...");
+        final IAppContainer ret = new IAppContainer() {
+            @Override
+            public Class<? extends Application> getContainedAppClass() {
+                return clazz;
+            }
+
+            @Override
+            public ResourceLocation getAppId() {
+                return new ResourceLocation(app.modId(), app.appId());
+            }
+
+            @Override
+            public boolean isDebug() {
+                return app.isDebug();
+            }
+
+            @Override
+            public boolean isSystemApp(){
+                return app.isSystemApp();
+            }
+        };
+        MrCrayfishDeviceMod.getLogger().info("\tDone!");
+        return ret;
+    }
+
+    public static void registerApps(){
+        MrCrayfishDeviceMod.getLogger().info("Registering annotated apps...");
+        for(IAppContainer app : apps){
+            MrCrayfishDeviceMod.getLogger().info(app.getAppId());
+            ApplicationManager.registerApplication(app);
+        }
+    }
+}

--- a/src/main/java/com/mrcrayfish/device/api/app/registry/IAppContainer.java
+++ b/src/main/java/com/mrcrayfish/device/api/app/registry/IAppContainer.java
@@ -1,0 +1,14 @@
+package com.mrcrayfish.device.api.app.registry;
+
+import com.mrcrayfish.device.api.app.Application;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.ResourceLocation;
+
+import javax.annotation.Nullable;
+
+public interface IAppContainer {
+    Class<? extends Application> getContainedAppClass();
+    ResourceLocation getAppId();
+    boolean isDebug();
+    boolean isSystemApp();
+}

--- a/src/main/java/com/mrcrayfish/device/programs/example/ApplicationExample.java
+++ b/src/main/java/com/mrcrayfish/device/programs/example/ApplicationExample.java
@@ -1,5 +1,7 @@
 package com.mrcrayfish.device.programs.example;
 
+import com.mrcrayfish.device.Reference;
+import com.mrcrayfish.device.api.app.registry.App;
 import com.mrcrayfish.device.api.task.TaskManager;
 import com.mrcrayfish.device.api.app.Application;
 import com.mrcrayfish.device.api.app.Icons;
@@ -11,6 +13,7 @@ import net.minecraft.nbt.NBTTagCompound;
 
 import javax.annotation.Nullable;
 
+@App(modId=Reference.MOD_ID, appId="example")
 public class ApplicationExample extends Application
 {
 	private Label label;
@@ -45,18 +48,12 @@ public class ApplicationExample extends Application
 		
 		button = new Button(5, 18, "Button");
 		button.setSize(63, 20);
-		button.setClickListener((mouseX, mouseY, mouseButton) ->
-		{
-            itemList.addItem("Henlo");
-        });
+		button.setClickListener((mouseX, mouseY, mouseButton) -> itemList.addItem("Henlo"));
 		super.addComponent(button);
 		
 		leftButton = new Button(5, 43, Icons.CHEVRON_LEFT);
 		leftButton.setPadding(1);
-		leftButton.setClickListener((mouseX, mouseY, mouseButton) ->
-		{
-			itemList.removeItem(itemList.getSelectedIndex());
-        });
+		leftButton.setClickListener((mouseX, mouseY, mouseButton) -> itemList.removeItem(itemList.getSelectedIndex()));
 		super.addComponent(leftButton);
 		
 		upButton = new Button(22, 43, Icons.CHEVRON_UP);
@@ -69,13 +66,10 @@ public class ApplicationExample extends Application
 		
 		downButton = new Button(56, 43, Icons.CHEVRON_DOWN);
 		downButton.setPadding(1);
-		downButton.setClickListener((mouseX, mouseY, mouseButton) ->
-		{
-			TaskManager.sendTask(new TaskNotificationTest());
-        });
+		downButton.setClickListener((mouseX, mouseY, mouseButton) -> TaskManager.sendTask(new TaskNotificationTest()));
 		super.addComponent(downButton);
 		
-		itemList = new ItemList<String>(5, 60, 63, 4);
+		itemList = new ItemList<>(5, 60, 63, 4);
 		itemList.addItem("Item #1");
 		itemList.addItem("Item #2");
 		itemList.addItem("Item #3");
@@ -105,14 +99,7 @@ public class ApplicationExample extends Application
 		super.addComponent(progressBar);
 		
 		slider = new Slider(88, 111, 80);
-		slider.setSlideListener(new SlideListener()
-		{
-			@Override
-			public void onSlide(float percentage)
-			{
-				progressBar.setProgress((int) (100 * percentage));
-			}
-		});
+		slider.setSlideListener(percentage -> progressBar.setProgress((int) (100 * percentage)));
 		super.addComponent(slider);
 		
 		spinner = new Spinner(56, 3);

--- a/src/main/java/com/mrcrayfish/device/proxy/CommonProxy.java
+++ b/src/main/java/com/mrcrayfish/device/proxy/CommonProxy.java
@@ -1,6 +1,7 @@
 package com.mrcrayfish.device.proxy;
 
 import com.mrcrayfish.device.api.app.Application;
+import com.mrcrayfish.device.api.app.registry.IAppContainer;
 import com.mrcrayfish.device.api.print.IPrint;
 import com.mrcrayfish.device.init.DeviceBlocks;
 import com.mrcrayfish.device.network.PacketHandler;


### PR DESCRIPTION
I went ahead and created that annotation you were talking about. It was pretty simple tbh. I didn't have to changed anything in the original code, just had to provide a way for the app class to be pushed from the annotation backend to the actual registration system: `ApplicationManager#registerApplication`. Created a simple wrapper interface that gets implemented when the class gets hooked through the annotation. The annotation's information gets passed into said interface, `IAppContainer`, as well as the class instance of the app class gets stored in the interface instance as well to be passed into the original registration system.